### PR TITLE
[IMP] Add Dockerhub tags for Odoo versions in Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,27 @@ services:
   - docker
 
 env:
+  global:
+    - DOCKER_REPO="laslabs/alpine-odoo"
+    - PROD_BRANCH="master"
   matrix:
     - ODOO_VERSION="10.0"
     - ODOO_VERSION="9.0"
 
 before_install:
   - docker pull kiasaki/alpine-postgres
-  - docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db kiasaki/alpine-postgres
+  - docker run -d -e POSTGRES_USER="odoo" -e POSTGRES_PASSWORD="odoo" --name="db" kiasaki/alpine-postgres
 
 install:
-  - docker build -t $TRAVIS_BUILD_NUMBER --build-arg ODOO_VERSION=$ODOO_VERSION $TRAVIS_BUILD_DIR/
+  - docker build --tag="${DOCKER_REPO}:${ODOO_VERSION}" --build-arg ODOO_VERSION=$ODOO_VERSION $TRAVIS_BUILD_DIR/
 
 script:
-  - docker run -d -p 8069:8069 --name $TRAVIS_BUILD_NUMBER --link db:db -t $TRAVIS_BUILD_NUMBER
-  - sleep 10
-  - curl --fail http://localhost:8069/web/database/manager
+  - docker run -d -t --publish="8069:8069" --name="$TRAVIS_BUILD_NUMBER" --link="db:db" "${DOCKER_REPO}:${ODOO_VERSION}"
+  - sleep 5  # Let Odoo boot
+  - curl --fail http://localhost:8069/web
+
+after_success:
+  - 'if [ "$TRAVIS_BRANCH" == "$PROD_BRANCH" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; \
+      then \
+        docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && docker push $DOCKER_REPO:$ODOO_VERSION; \
+      fi'

--- a/README.md
+++ b/README.md
@@ -44,10 +44,23 @@ You can use any Postgres server or Docker image for this. We will use
 Start an Odoo Instance
 ----------------------
 
-    docker run -p 8069:8069 --name odoo --link db:db -t laslabs/alpine-odoo
+The below command will run a container with the latest version of Odoo:
 
-The alias of the container running Postgres must be db for Odoo to be able
- to connect to the Postgres server.
+    docker run -p 8069:8069 --name odoo --link db:db -t laslabs/alpine-odoo:latest
+
+You can run different versions by using the appropriate tag:
+
+    # Version 10
+    docker run -p 8069:8069 --name odoo --link db:db -t laslabs/alpine-odoo:10.0
+    # Version 9
+    docker run -p 8069:8069 --name odoo --link db:db -t laslabs/alpine-odoo:9.0
+    # Version 8
+    docker run -p 8069:8069 --name odoo --link db:db -t laslabs/alpine-odoo:8.0
+
+The alias of the container running Postgres must be `db` for Odoo to be able
+ to connect to the Postgres server by using default options. See the [Environment
+ Variables](#environment-variables) section for more information on how to change
+ this.
 
 Stop and Restart an Odoo Instance
 ---------------------------------


### PR DESCRIPTION
This pushes the Odoo versions in the Travis matrix as tags to Dockerhub so that all of the builds are available (latest will only be default, which is currently 10.0)

Tags were built successfully while testing, then I switched the Travis `PROD_BRANCH` var back to master & confirmed it didn't build. It also didn't build either times during a PR, which is good because the name of the branch on a PR is the target not the source.

* https://hub.docker.com/r/laslabs/alpine-odoo/tags/

Note that the tags are all version 10 Odoo due to an issue in the first commit that was since resolved in the relevant PR.

Depends:
- [ ] #1 